### PR TITLE
chore: remove StopStalk (sunset Aug 2025)

### DIFF
--- a/data/topicList.js
+++ b/data/topicList.js
@@ -4639,11 +4639,6 @@ export const usefulLinks = [
   },
   {
     title:
-      "StopStalk — Track your progress on various competitive programming websites at one place",
-    link: "https://www.stopstalk.com/",
-  },
-  {
-    title:
       "CP Algorithms — A great resource for Algorithms for Competitive Programming",
     link: "https://cp-algorithms.com/index.html",
   },


### PR DESCRIPTION
> StopStalk will not be available for usage post 1st August 2025 